### PR TITLE
Fix: Prevent DPoS panic when no delegates are present

### DIFF
--- a/consensus/dpos.go
+++ b/consensus/dpos.go
@@ -313,28 +313,6 @@ func (d *DPoS) Initialize(nodeID string) error {
 
 	// Creamos delegados para simulación
 	// En producción, estos se registrarían dinámicamente
-	delegatesList := []string{}
-
-	// Initialize delegates with random stake
-	now := time.Now().UTC().Format(time.RFC3339)
-	for _, id := range delegatesList {
-		stake := 100.0 + float64(rand.Intn(900))
-		reliability := 95.0 + float64(rand.Intn(5)) // 95-100% reliability
-
-		d.Delegates[id] = &DelegateInfo{
-			NodeID:        id,
-			Stake:         stake,
-			Votes:         0,
-			BlocksCreated: 0,
-			IsActive:      false,
-			LastActive:    now,
-			Reliability:   reliability,
-			RewardAccrued: 0.0,
-			MissedBlocks:  0,
-			CreationTime:  now,
-		}
-		d.StakeByNodeID[id] = stake
-	}
 
 	// Set up initial active delegates
 	d.UpdateActiveDelegates()
@@ -381,6 +359,10 @@ func (d *DPoS) updateSchedule() {
 		}
 
 		// Update current producer
+		if len(d.ActiveDelegates) == 0 || len(d.ActiveDelegates) < d.RoundLength {
+			utils.LogInfo("Waiting for sufficient delegates to join. Currently have %d, need %d.", len(d.ActiveDelegates), d.RoundLength)
+			return
+		}
 		d.CurrentProducer = d.ActiveDelegates[d.CurrentSlot]
 
 		utils.LogInfo("DPoS schedule updated. Round: %d, Slot: %d, Producer: %s",


### PR DESCRIPTION
The DPoS consensus mechanism would panic if initialized or run without any delegates registered. This was due to an attempt to access an empty `ActiveDelegates` list in `updateSchedule`.

This commit addresses the issue by:
1. Removing the obsolete hardcoded/simulated delegate list from the `Initialize` function. Delegates are now expected to be registered dynamically.
2. Modifying `updateSchedule` to check if there are enough active delegates (i.e., `len(ActiveDelegates) >= RoundLength`). If not, it logs a waiting message and skips block producer selection for that tick, preventing the out-of-bounds panic. The system will wait for delegates to be registered via network messages.
3. Verifying that `UpdateActiveDelegates` correctly handles the case of zero registered delegates, resulting in an empty `ActiveDelegates` list, which is now gracefully handled by `updateSchedule`.
4. Verifying that delegate registration functions (`handleNewDelegate`, `RegisterDelegate`) correctly populate the main `Delegates` list.

With these changes, the node will wait for delegates to register dynamically instead of panicking if none are available at startup or during a round update.