### PR TITLE
Fix: Correct signBlock and PrivateKey errors in p2p/network.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -247,6 +247,8 @@ func main() {
 	utils.LogInfo("Background processing (mempools) started")
 	go p2pServer.SyncChains()                  // Initial chain sync
 	go updateValidatorsPeriodically(p2pServer) // DPoS validator updates
+	go p2p.StartPBFTWebsocketServer(nodeID, 8546, consensusCritical) // Start PBFT WebSocket server
+	go p2p.StartPBOSWebsocketServer(nodeID, 8547) // Start pBOS WebSocket server
 
 	// 9. Setup Graceful Shutdown
 	// Pass p2pServer to shutdown its HTTP server as well

--- a/p2p/network.go
+++ b/p2p/network.go
@@ -26,7 +26,7 @@ func (s *Server) BroadcastNewBlock(block *blockchain.Block, chainType string) {
 	}
 
 	// Firmar el bloque
-	message.Signature = s.signBlock(block.Hash, s.Node.PrivateKey)
+	message.Signature = s.signBlock(block.Hash)
 
 	blockData, _ := json.Marshal(block)
 

--- a/p2p/pbft_websocket_handler.go
+++ b/p2p/pbft_websocket_handler.go
@@ -1,0 +1,148 @@
+package p2p
+
+import (
+	"encoding/json" // Added for unmarshaling consensus messages
+	"fmt"
+	"log"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"tripcodechain_go/consensus" // Added for consensus interface and types
+	"tripcodechain_go/utils"
+)
+
+// upgrader is used to upgrade HTTP connections to WebSocket connections.
+var upgrader = websocket.Upgrader{
+	CheckOrigin: func(r *http.Request) bool {
+		return true // Allow all connections for now
+	},
+}
+
+// pbftClients stores active WebSocket connections for PBFT.
+var pbftClients = make(map[*websocket.Conn]bool)
+var pbftClientsMutex = sync.RWMutex{}
+
+// StartPBFTWebsocketServer starts the WebSocket server for PBFT communication.
+// It now accepts a consensus.Consensus interface to pass messages to the PBFT engine.
+func StartPBFTWebsocketServer(nodeID string, port int, pbftConsensus consensus.Consensus) {
+	utils.LogInfo("[PBFT_WS] Attempting to start PBFT WebSocket server for node %s on port %d", nodeID, port)
+
+	http.HandleFunc("/pbft", func(w http.ResponseWriter, r *http.Request) {
+		// pbftConsensus is available here due to closure
+		pbftWsHandler(w, r, nodeID, pbftConsensus)
+	})
+
+	addr := fmt.Sprintf(":%d", port)
+	utils.LogInfo("[PBFT_WS] Listening on %s/pbft", addr)
+	if err := http.ListenAndServe(addr, nil); err != nil {
+		log.Fatalf("[PBFT_WS] Failed to start PBFT WebSocket server: %v", err)
+	}
+}
+
+// pbftWsHandler handles incoming WebSocket connections for PBFT.
+// It now takes pbftConsensus to process messages.
+func pbftWsHandler(w http.ResponseWriter, r *http.Request, serverNodeID string, pbftConsensus consensus.Consensus) {
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		utils.LogError("[PBFT_WS] Failed to upgrade connection for %s: %v", r.RemoteAddr, err)
+		return
+	}
+	defer conn.Close()
+
+	pbftClientsMutex.Lock()
+	pbftClients[conn] = true
+	pbftClientsMutex.Unlock()
+
+	utils.LogInfo("[PBFT_WS] Connection established with %s", r.RemoteAddr)
+	LogPBFTConnectionEstablished(serverNodeID, r.RemoteAddr, time.Duration(0))
+
+	defer func() {
+		pbftClientsMutex.Lock()
+		delete(pbftClients, conn)
+		pbftClientsMutex.Unlock()
+		utils.LogInfo("[PBFT_WS] Connection closed with %s", r.RemoteAddr)
+	}()
+
+	for {
+		_, messageBytes, err := conn.ReadMessage() // messageType is _
+		if err != nil {
+			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
+				utils.LogError("[PBFT_WS] Error reading message from %s: %v", r.RemoteAddr, err)
+			} else {
+				utils.LogInfo("[PBFT_WS] Client %s disconnected.", r.RemoteAddr)
+			}
+			break
+		}
+
+		var msg consensus.Message
+		if err := json.Unmarshal(messageBytes, &msg); err != nil {
+			utils.LogError("[PBFT_WS] Failed to unmarshal PBFT message from %s: %v. Message: %s", r.RemoteAddr, err, string(messageBytes))
+			continue
+		}
+
+		utils.LogDebug("[PBFT_WS] Received %s message from %s", msg.Type, conn.RemoteAddr().String())
+
+		pbftInstance, ok := pbftConsensus.(*consensus.PBFT)
+		if !ok {
+			utils.LogError("[PBFT_WS] PBFT consensus instance is not of type *PBFT for node %s. Cannot process message.", serverNodeID)
+			continue // Or handle more gracefully, maybe this server shouldn't run if consensus is wrong type
+		}
+
+		if err := pbftInstance.ProcessConsensusMessage(&msg); err != nil {
+			utils.LogError("[PBFT_WS] Error processing PBFT message type %s from %s: %v", msg.Type, r.RemoteAddr, err)
+			continue
+		}
+		// Successfully processed message
+		utils.LogDebug("[PBFT_WS] Successfully processed %s message from %s", msg.Type, conn.RemoteAddr().String())
+	}
+}
+
+// BroadcastPBFTMessage sends a message to all connected PBFT WebSocket clients.
+func BroadcastPBFTMessage(message []byte) {
+	pbftClientsMutex.RLock()
+	defer pbftClientsMutex.RUnlock()
+
+	if len(pbftClients) == 0 {
+		// utils.LogInfo("[PBFT_WS] No PBFT clients connected, cannot broadcast message.") // Can be noisy
+		return
+	}
+
+	// utils.LogDebug("[PBFT_WS] Broadcasting message to %d PBFT clients.", len(pbftClients)) // Can be noisy
+	for client := range pbftClients {
+		err := client.WriteMessage(websocket.TextMessage, message)
+		if err != nil {
+			utils.LogError("[PBFT_WS] Error writing message to client %s: %v", client.RemoteAddr().String(), err)
+		}
+	}
+}
+
+// LogPBFTConnectionEstablished logs when a PBFT WebSocket connection is established.
+func LogPBFTConnectionEstablished(nodeID string, connectedNodeID string, latency time.Duration) {
+	timestamp := time.Now().Format("2006-01-02 15:04:05.000")
+	latencyMs := latency.Milliseconds()
+	utils.LogInfo("[%s] VALIDATOR_NODE: PBFT_connection_established - Node:%s (connectedTo:%s) - Latency:%dms", timestamp, nodeID, connectedNodeID, latencyMs)
+}
+
+// LogPBFTLeaderElection logs when a new leader is elected in the PBFT process.
+func LogPBFTLeaderElection(nodeID string, electedLeaderID string, latency time.Duration) {
+	timestamp := time.Now().Format("2006-01-02 15:04:05.000")
+	latencyMs := latency.Milliseconds()
+	utils.LogInfo("[%s] VALIDATOR_NODE: PBFT_leader_election - Node:%s (electedLeader:%s) - Latency:%dms", timestamp, nodeID, electedLeaderID, latencyMs)
+}
+
+// LogPBFTViewChange logs when a view change occurs in the PBFT process.
+// newViewID is assumed to be a string representation of the view identifier.
+func LogPBFTViewChange(nodeID string, newViewID string, latency time.Duration) {
+	timestamp := time.Now().Format("2006-01-02 15:04:05.000")
+	latencyMs := latency.Milliseconds()
+	utils.LogInfo("[%s] VALIDATOR_NODE: PBFT_view_change - Node:%s (newView:%s) - Latency:%dms", timestamp, nodeID, newViewID, latencyMs)
+}
+
+// LogPBFTConsensusReached logs when consensus is reached on a block in the PBFT process.
+func LogPBFTConsensusReached(nodeID string, blockID string, latency time.Duration) {
+	timestamp := time.Now().Format("2006-01-02 15:04:05.000")
+	latencyMs := latency.Milliseconds()
+	utils.LogInfo("[%s] VALIDATOR_NODE: PBFT_consensus_reached - Node:%s (blockID:%s) - Latency:%dms", timestamp, nodeID, blockID, latencyMs)
+}

--- a/p2p/pbos_websocket_handler.go
+++ b/p2p/pbos_websocket_handler.go
@@ -1,0 +1,126 @@
+package p2p
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"tripcodechain_go/utils"
+)
+
+// pbosUpgrader is used to upgrade HTTP connections to WebSocket connections for pBOS.
+var pbosUpgrader = websocket.Upgrader{
+	CheckOrigin: func(r *http.Request) bool {
+		return true // Allow all connections for now
+	},
+}
+
+// pbosClients stores active WebSocket connections for pBOS.
+var pbosClients = make(map[*websocket.Conn]bool)
+var pbosClientsMutex = sync.RWMutex{}
+
+// StartPBOSWebsocketServer starts the WebSocket server for pBOS communication.
+func StartPBOSWebsocketServer(nodeID string, port int) {
+	utils.LogInfo("[pBOS_WS] Attempting to start pBOS WebSocket server for node %s on port %d", nodeID, port)
+
+	http.HandleFunc("/pbos", func(w http.ResponseWriter, r *http.Request) {
+		pbosWsHandler(w, r, nodeID) // Pass nodeID to the handler
+	})
+
+	addr := fmt.Sprintf(":%d", port)
+	utils.LogInfo("[pBOS_WS] Listening on %s/pbos", addr)
+	if err := http.ListenAndServe(addr, nil); err != nil {
+		log.Fatalf("[pBOS_WS] Failed to start pBOS WebSocket server: %v", err)
+	}
+}
+
+// pbosWsHandler handles incoming WebSocket connections for pBOS.
+func pbosWsHandler(w http.ResponseWriter, r *http.Request, serverNodeID string) {
+	conn, err := pbosUpgrader.Upgrade(w, r, nil)
+	if err != nil {
+		utils.LogError("[pBOS_WS] Failed to upgrade connection for %s: %v", r.RemoteAddr, err)
+		return
+	}
+	defer conn.Close()
+
+	// Add client to the map
+	pbosClientsMutex.Lock()
+	pbosClients[conn] = true
+	pbosClientsMutex.Unlock()
+
+	utils.LogInfo("[pBOS_WS] Connection established with %s", r.RemoteAddr)
+	LogPBOSPeerJoined(serverNodeID, r.RemoteAddr, time.Duration(0))
+
+	// Ensure client is removed from the map when the handler exits
+	defer func() {
+		pbosClientsMutex.Lock()
+		delete(pbosClients, conn)
+		pbosClientsMutex.Unlock()
+		utils.LogInfo("[pBOS_WS] Connection closed with %s", r.RemoteAddr)
+	}()
+
+	// Placeholder loop for reading messages
+	for {
+		messageType, message, err := conn.ReadMessage()
+		if err != nil {
+			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
+				utils.LogError("[pBOS_WS] Error reading message from %s: %v", r.RemoteAddr, err)
+			} else {
+				utils.LogInfo("[pBOS_WS] Client %s disconnected.", r.RemoteAddr)
+			}
+			break
+		}
+		// For now, just log received messages.
+		log.Printf("[pBOS_WS] Received from %s (type %d): %s", r.RemoteAddr, messageType, message)
+	}
+}
+
+// BroadcastPBOSMessage sends a message to all connected pBOS WebSocket clients.
+func BroadcastPBOSMessage(message []byte) {
+	pbosClientsMutex.RLock()
+	defer pbosClientsMutex.RUnlock()
+
+	if len(pbosClients) == 0 {
+		utils.LogInfo("[pBOS_WS] No pBOS clients connected, cannot broadcast message.")
+		return
+	}
+
+	utils.LogInfo("[pBOS_WS] Broadcasting message to %d pBOS clients.", len(pbosClients))
+	for client := range pbosClients {
+		err := client.WriteMessage(websocket.TextMessage, message)
+		if err != nil {
+			utils.LogError("[pBOS_WS] Error writing message to client %s: %v", client.RemoteAddr().String(), err)
+		}
+	}
+}
+
+// LogPBOSPeerJoined logs when a peer joins the pBOS network.
+func LogPBOSPeerJoined(nodeID string, joinedPeerID string, latency time.Duration) {
+	timestamp := time.Now().Format("2006-01-02 15:04:05.000")
+	latencyMs := latency.Milliseconds()
+	utils.LogInfo("[%s] VALIDATOR_NODE: PBOS_peer_joined - Node:%s (joinedPeer:%s) - Latency:%dms", timestamp, nodeID, joinedPeerID, latencyMs)
+}
+
+// LogPBOSTransactionBroadcast logs when a transaction is broadcast in the pBOS network.
+func LogPBOSTransactionBroadcast(nodeID string, transactionID string, latency time.Duration) {
+	timestamp := time.Now().Format("2006-01-02 15:04:05.000")
+	latencyMs := latency.Milliseconds()
+	utils.LogInfo("[%s] VALIDATOR_NODE: PBOS_transaction_broadcast - Node:%s (transactionID:%s) - Latency:%dms", timestamp, nodeID, transactionID, latencyMs)
+}
+
+// LogPBOSBlockValidation logs the result of a block validation in the pBOS network.
+func LogPBOSBlockValidation(nodeID string, blockID string, isValid bool, latency time.Duration) {
+	timestamp := time.Now().Format("2006-01-02 15:04:05.000")
+	latencyMs := latency.Milliseconds()
+	utils.LogInfo("[%s] VALIDATOR_NODE: PBOS_block_validation - Node:%s (blockID:%s, isValid:%t) - Latency:%dms", timestamp, nodeID, blockID, isValid, latencyMs)
+}
+
+// LogPBOSFinalityConfirmation logs when block finality is confirmed in the pBOS network.
+func LogPBOSFinalityConfirmation(nodeID string, blockID string, latency time.Duration) {
+	timestamp := time.Now().Format("2006-01-02 15:04:05.000")
+	latencyMs := latency.Milliseconds()
+	utils.LogInfo("[%s] VALIDATOR_NODE: PBOS_finality_confirmation - Node:%s (blockID:%s) - Latency:%dms", timestamp, nodeID, blockID, latencyMs)
+}

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -2,6 +2,7 @@ package p2p
 
 import (
 	"context" // Added for Shutdown method
+	"encoding/base64" // Added for signBlock
 	"encoding/json"
 	"fmt"
 	// "log" // Removed as unused
@@ -160,6 +161,25 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	}
 	utils.LogInfo("HTTP server shutting down...")
 	return s.httpServer.Shutdown(ctx)
+}
+
+// signBlock signs a block hash using the node's signer.
+// It returns the base64 encoded signature or an empty string on error.
+func (s *Server) signBlock(blockHash string) string {
+	data := []byte(blockHash)
+
+	if s.Node == nil || s.Node.Signer == nil {
+		utils.LogError("signBlock: Node or Signer is nil")
+		return ""
+	}
+
+	signatureBytes, err := s.Node.Signer.Sign(data)
+	if err != nil {
+		utils.LogError("signBlock: Error signing data: %v", err)
+		return ""
+	}
+
+	return base64.StdEncoding.EncodeToString(signatureBytes)
 }
 
 // StartBackgroundProcessing starts the mempool processing jobs


### PR DESCRIPTION
Resolved undefined method/field errors by:
- Adding a `signBlock` method to `p2p.Server` which uses the node's signer.
- Updating the call site in `p2p.network.go`'s `BroadcastNewBlock` to use the new `signBlock` method signature.

Feat: Add WebSocket handlers and logging for PBFT and pBOS consensus

Implemented a framework for WebSocket-based communication for PBFT and pBOS consensus mechanisms, including event-specific logging.

Key changes:
- Created `p2p/pbft_websocket_handler.go`:
  - Sets up a WebSocket server listening on port 8546.
  - Manages client connections.
  - Implements `BroadcastPBFTMessage` for outgoing messages.
  - Processes incoming messages, deserializes them, and passes them to the PBFT consensus engine (`consensusCritical.ProcessConsensusMessage`).
  - Adds logging for PBFT events: `connection_established`, `leader_election`, `view_change`, `consensus_reached` using the specified format.
- Created `p2p/pbos_websocket_handler.go`:
  - Sets up a WebSocket server listening on port 8547.
  - Manages client connections.
  - Implements `BroadcastPBOSMessage` for outgoing messages.
  - Currently logs incoming raw messages; full processing awaits pBOS consensus logic implementation.
  - Adds logging for pBOS events: `peer_joined`, `transaction_broadcast`, `block_validation`, `finality_confirmation` using the specified format.
- Integrated the startup of these WebSocket servers into `main.go`.
- Modified `consensus/pbft.go`:
  - PBFT message broadcast functions (`BroadcastPrepare`, `BroadcastCommit`, `InitiateViewChange`) now serialize messages to JSON and call `p2p.BroadcastPBFTMessage`.
  - PBFT consensus events (`ViewChange`, `ConsensusReached`) now trigger logging via the functions in `pbft_websocket_handler.go`.
- Logging uses the `utils.LogInfo` utility with the format: `[timestamp] VALIDATOR_NODE: CONSENSUS_event_type - Node:node_id - Latency:ms_ms` as requested.