### PR TITLE
feat: Introduce dynamic validator count based on APP_ENV

### DIFF
--- a/blockchain/constants.go
+++ b/blockchain/constants.go
@@ -1,5 +1,7 @@
 package blockchain
 
+import "os"
+
 // BlockType represents the type of a block in the blockchain
 type BlockType string
 
@@ -13,8 +15,10 @@ const (
 const (
 	// MinValidatorStake defines the minimum stake required to become a validator.
 	MinValidatorStake = 100
-	// NumberOfDelegates defines the number of active delegates in the DPoS system.
+	// NumberOfDelegates defines the number of active delegates in the DPoS system for production.
 	NumberOfDelegates = 21
+	// NumberOfDelegatesDev defines the number of active delegates in the DPoS system for development.
+	NumberOfDelegatesDev = 7
 	// ReliabilityThreshold is the minimum reliability score before a validator is marked inactive.
 	ReliabilityThreshold = 50.0
 	// ReliabilityChangeRate is the amount by which reliability score changes.
@@ -30,3 +34,12 @@ const (
 	// BlockRewardAmount is the amount of TripCoins rewarded for creating a block.
 	BlockRewardAmount = 2
 )
+
+// GetNumberOfDelegates returns the number of delegates based on the APP_ENV environment variable.
+// It defaults to the production value if APP_ENV is not "development".
+func GetNumberOfDelegates() int {
+	if os.Getenv("APP_ENV") == "development" {
+		return NumberOfDelegatesDev
+	}
+	return NumberOfDelegates
+}

--- a/blockchain/constants_test.go
+++ b/blockchain/constants_test.go
@@ -1,0 +1,80 @@
+package blockchain
+
+import (
+	"os"
+	"testing"
+)
+
+func TestGetNumberOfDelegates(t *testing.T) {
+	// Helper function to safely get and restore environment variables
+	setEnvForTest := func(t *testing.T, key, value string) {
+		originalValue, wasSet := os.LookupEnv(key)
+		if err := os.Setenv(key, value); err != nil {
+			t.Fatalf("Failed to set env %s: %v", key, err)
+		}
+		t.Cleanup(func() {
+			if !wasSet {
+				os.Unsetenv(key)
+			} else {
+				if err := os.Setenv(key, originalValue); err != nil {
+					t.Logf("Failed to restore env %s: %v", key, err) // Log instead of Fatal in cleanup
+				}
+			}
+		})
+	}
+
+	unsetEnvForTest := func(t *testing.T, key string) {
+		originalValue, wasSet := os.LookupEnv(key)
+		if !wasSet { // Nothing to do if not set
+			return
+		}
+		if err := os.Unsetenv(key); err != nil {
+			t.Fatalf("Failed to unset env %s: %v", key, err)
+		}
+		t.Cleanup(func() {
+			// Only restore if it was originally set.
+			// If it wasn't set, Unsetenv did its job and we shouldn't try to Setenv to empty.
+			if wasSet {
+				if err := os.Setenv(key, originalValue); err != nil {
+					t.Logf("Failed to restore env %s after unsetting: %v", key, err)
+				}
+			}
+		})
+	}
+
+	t.Run("DevelopmentEnv", func(t *testing.T) {
+		setEnvForTest(t, "APP_ENV", "development")
+		expected := NumberOfDelegatesDev
+		actual := GetNumberOfDelegates()
+		if actual != expected {
+			t.Errorf("Expected %d delegates for APP_ENV=development, got %d", expected, actual)
+		}
+	})
+
+	t.Run("ProductionEnv", func(t *testing.T) {
+		setEnvForTest(t, "APP_ENV", "production")
+		expected := NumberOfDelegates
+		actual := GetNumberOfDelegates()
+		if actual != expected {
+			t.Errorf("Expected %d delegates for APP_ENV=production, got %d", expected, actual)
+		}
+	})
+
+	t.Run("NonDevelopmentEnv", func(t *testing.T) {
+		setEnvForTest(t, "APP_ENV", "staging") // Any value other than "development"
+		expected := NumberOfDelegates
+		actual := GetNumberOfDelegates()
+		if actual != expected {
+			t.Errorf("Expected %d delegates for APP_ENV=staging, got %d", expected, actual)
+		}
+	})
+
+	t.Run("UnsetEnv", func(t *testing.T) {
+		unsetEnvForTest(t, "APP_ENV")
+		expected := NumberOfDelegates
+		actual := GetNumberOfDelegates()
+		if actual != expected {
+			t.Errorf("Expected %d delegates when APP_ENV is not set, got %d", expected, actual)
+		}
+	})
+}

--- a/pkg/validation/dpos.go
+++ b/pkg/validation/dpos.go
@@ -78,7 +78,7 @@ func NewDPoS(currencyManager *currency.CurrencyManager) *DPoS { // Returns *vali
 		Delegates:        make(map[string]*DelegateInfo),
 		Validators:       make(map[string]Validator),
 		ActiveDelegates:  make([]string, 0),
-		RoundLength:      21,
+		RoundLength:      blockchain.GetNumberOfDelegates(),
 		BlockTime:        3,
 		StakeByNodeID:    make(map[string]float64),
 		VotesByNodeID:    make(map[string]string),
@@ -714,7 +714,7 @@ func SelectDelegates(dpos *DPoS) error {
 		val.IsActive = false
 		dpos.Validators[address] = val
 	}
-	numDelegates := blockchain.NumberOfDelegates
+	numDelegates := blockchain.GetNumberOfDelegates()
 	if len(validators) < numDelegates {
 		numDelegates = len(validators)
 	}


### PR DESCRIPTION
This change modifies the DPoS validator configuration to support a different number of validators in development versus production environments.

- In development (APP_ENV=development), the number of validators is set to 7.
- In production (or when APP_ENV is not 'development'), the number of validators remains 21.

Key changes:
- Added `NumberOfDelegatesDev` constant in `blockchain/constants.go`.
- Introduced `blockchain.GetNumberOfDelegates()` to retrieve the validator count based on `APP_ENV`.
- Updated DPoS initialization (`pkg/validation/dpos.go`) to use `GetNumberOfDelegates()` for `RoundLength`.
- Updated delegate selection logic (`pkg/validation/dpos.go`) to use `GetNumberOfDelegates()`.
- Added `blockchain/constants_test.go` with tests for `GetNumberOfDelegates()` to verify its behavior with different `APP_ENV` settings.